### PR TITLE
Add Docker support for MCP Obsidian server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-slim
+
+WORKDIR /app
+
+RUN npm install -g typescript shx
+
+COPY . .
+
+RUN npm ci && \
+    npm run build
+    
+ENTRYPOINT ["node", "dist/index.js"] 


### PR DESCRIPTION
## Description
Adds Docker configuration for running the MCP Obsidian server with Claude Desktop.

## Sample Configuration
Add to your `claude_desktop_config.json`:

```json
{
  "mcpServers": {
    "obsidian": {
      "command": "docker",
      "args": [
        "run", 
        "-i", 
        "--rm", 
        "--init", 
        "-v", 
        "/path/to/obsidian/vault:/vault:ro", 
        "mcp/obsidian", 
        "/vault"
      ]
    }
  }
}
```

## Setup
2. Replace `/path/to/obsidian/vault` with your vault path
3. Restart Claude Desktop